### PR TITLE
minor MarkDown: remove space in Open Daylight Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | [GCI](https://www.google-melange.com/gci/homepage/google/gci2014) | Prizes for winners |
 | [GSOC](https://developers.google.com/open-source/gsoc/) | Yes |
 | [SOCIS](http://sophia.estec.esa.int/socis/) | Yes (For students enrolled in ESA [member states](http://sophia.estec.esa.int/socis2013/?q=faq#socis_elig_student_who) only) |
-| [OpenDaylight summer internship program] (https://www.opendaylight.org/opendaylight-summer-internship-program) | Yes |
+| [OpenDaylight summer internship program](https://www.opendaylight.org/opendaylight-summer-internship-program) | Yes |
 | [The X.Org Endless Vacation of Code (EVoC)](http://www.x.org/wiki/XorgEVoC/)| Yes |
 | [DataONE Summer Internship Program](https://www.dataone.org/internships) | Yes*|
 | [Free Software Foundation Internship](http://www.fsf.org/volunteer/internships) | No|


### PR DESCRIPTION
### before:
![Screenshot of row where long url is visible](https://cloud.githubusercontent.com/assets/2482343/24771501/c8f2e2e6-1adb-11e7-83a2-93b22cc6ad0f.png)

### after:
![Screenshot of row where link renders normally](https://cloud.githubusercontent.com/assets/2482343/24771502/c8f4755c-1adb-11e7-8fd6-fcbb697bd541.png)

Thanks!
