### PR TITLE
Updated an invalid link of OpenDayLight

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 | [GCI](https://www.google-melange.com/gci/homepage/google/gci2014) | Prizes for winners |
 | [GSOC](https://developers.google.com/open-source/gsoc/) | Yes |
 | [SOCIS](http://sophia.estec.esa.int/socis/) | Yes (For students enrolled in ESA [member states](http://sophia.estec.esa.int/socis2013/?q=faq#socis_elig_student_who) only) |
-| [OpenDaylight summer internship program](https://www.opendaylight.org/opendaylight-summer-internship-program) | Yes |
+| [OpenDaylight summer internship program](https://wiki.opendaylight.org/view/Interns) | Yes |
 | [The X.Org Endless Vacation of Code (EVoC)](http://www.x.org/wiki/XorgEVoC/)| Yes |
 | [DataONE Summer Internship Program](https://www.dataone.org/internships) | Yes*|
 | [Free Software Foundation Internship](http://www.fsf.org/volunteer/internships) | No|


### PR DESCRIPTION
The OpenDayLight internship programs link is invalid. Updated it to a new link, which is https://wiki.opendaylight.org/view/Interns