### PR TITLE
Added Hyperledger Internship

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 | [Segment Open Fellowship](https://open.segment.com/fellowship) | Yes |
 | [RARE Technologies Student Incubator Program](https://rare-technologies.com/incubator/#details) | Yes |
 | [Open Summer of Code](http://2017.summerofcode.be/) | Yes** |
+| [Hyperledger Internship Program](https://wiki.hyperledger.org/internship/program_overview) | Yes |
 
 *Interns must be currently enrolled or employed at a U.S. university or other research institution and must currently reside in, and be eligible to work in, the United States.
 ** OSoC is only open to Belgian students.


### PR DESCRIPTION
Similar to GSoC. All the projects are open sourced
hosted on Github. Stipend is similar to GSoC