### PR TITLE
Add John Hunter Technology Fellowship

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 | [RARE Technologies Student Incubator Program](https://rare-technologies.com/incubator/#details) | Yes |
 | [Open Summer of Code](http://2017.summerofcode.be/) | Yes** |
 | [Hyperledger Internship Program](https://wiki.hyperledger.org/internship/program_overview) | Yes |
+| [John Hunter Technology Fellowship](https://www.numfocus.org/programs/john-hunter-technology-fellowship) | Yes |
 
 *Interns must be currently enrolled or employed at a U.S. university or other research institution and must currently reside in, and be eligible to work in, the United States.
 ** OSoC is only open to Belgian students.


### PR DESCRIPTION
or John Hunter Matplotlib Summer Fellowship by Numfocus and Matplotlib. Discovered this recently. 2018 members: https://www.numfocus.org/blog/2018-john-hunter-matplotlib-summer-fellows. So I guess it's active. @tapasweni-pathak 